### PR TITLE
Improve conversation cleanup and command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ qwen-tui backends test
 qwen-tui config show
 ```
 
+### Slash Commands
+
+Inside the TUI you can use several helpful commands:
+
+```
+/help      Show keyboard shortcuts and command list
+/clear     Start a new conversation and clear history
+/history   List recent conversation sessions
+/load ID   Load a previous session by ID
+/export fmt  Export the current session (json or txt)
+```
+
 ## Features
 
 ### Multi-Backend Architecture

--- a/docs/agent_system_summary.md
+++ b/docs/agent_system_summary.md
@@ -24,6 +24,7 @@ The advanced agent tooling and action system has been successfully implemented w
 - **Task Tool**: ✅ Delegates complex operations
 - **MultiEdit Tool**: ✅ Performs atomic multi-file edits
 - **NotebookExecute Tool**: ✅ Executes code in notebook environments
+- **History Cleanup**: ✅ Old conversation logs cleaned automatically
 
 ## 🏗️ **Architecture Components**
 

--- a/docs/claude_code_architecture.md
+++ b/docs/claude_code_architecture.md
@@ -14,6 +14,7 @@ Claude Code follows a **REPL-based agent architecture** with a **Plan → Act �
 - Displays tool activities with visual indicators (`⏺` for tool use, `⎿` for completion)
 - Captures key events (Escape to edit, Ctrl+C to interrupt)
 - Uses monospace formatting appropriate for CLI
+- Cleans up stale conversation logs automatically
 
 ### 2. AI Integration (Reasoning Engine)
 - **Dual-model strategy**: Uses Claude 3.7 Sonnet for complex reasoning, Claude 3.5 Haiku for lightweight tasks

--- a/src/qwen_tui/history.py
+++ b/src/qwen_tui/history.py
@@ -265,8 +265,11 @@ class ConversationHistory:
                 ts_str = session_file.stem.replace("conversation_", "")
                 try:
                     file_time = datetime.strptime(ts_str, "%Y%m%d_%H%M%S_%f").timestamp()
-                except Exception:
-                    file_time = session_file.stat().st_mtime
+                except ValueError:
+                    try:
+                        file_time = datetime.strptime(ts_str, "%Y%m%d_%H%M%S").timestamp()
+                    except Exception:
+                        file_time = session_file.stat().st_mtime
 
                 if file_time < cutoff_time:
                     try:


### PR DESCRIPTION
## Summary
- handle history files without microsecond timestamps
- simplify help display and command output
- adjust conversation clearing for simple test panels
- add slash command overview in README
- document automatic history cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854232845b88324868ef7542c738140