### PR TITLE
Add openrouter model default and test report

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ vllm:
   model: Qwen/Qwen2.5-Coder-7B-Instruct
 openrouter:
   api_key: YOUR_API_KEY
-  model: qwen/qwen-2.5-coder-32b-instruct
+  model: deepseek/deepseek-r1-0528-qwen3-8b
 ```
 
 Set via environment variables if preferred:
@@ -145,7 +145,7 @@ Set via environment variables if preferred:
 ```bash
 export QWEN_TUI_VLLM_HOST=localhost
 export QWEN_TUI_VLLM_PORT=8000
-export QWEN_TUI_OPENROUTER_MODEL=qwen/qwen-2.5-coder-32b-instruct
+export QWEN_TUI_OPENROUTER_MODEL=deepseek/deepseek-r1-0528-qwen3-8b
 export OPENROUTER_API_KEY=<key>
 ```
 

--- a/docs/testing_report.md
+++ b/docs/testing_report.md
@@ -1,0 +1,34 @@
+# Testing Report
+
+## Environment
+- Python version: 3.12.10
+- Repo commit: 9dde952
+
+## Automated Tests
+
+All automated tests were executed with `pytest`:
+
+```
+.........................................................                [100%]
+=============================== warnings summary ===============================
+... (truncated warnings)
+```
+
+All tests passed successfully.
+
+## OpenRouter Connection Test
+
+The environment did not provide an `OPENROUTER_API_KEY`. Running a minimal test script resulted in:
+
+```
+API key: None
+No API key provided
+```
+
+A `curl` request to `https://openrouter.ai/api/v1/models` succeeded with HTTP 200, confirming network access to `openrouter.ai`.
+
+## Required Changes and Allowed Domains
+
+- The default OpenRouter model is now `deepseek/deepseek-r1-0528-qwen3-8b` across configuration files and documentation.
+- Provide `OPENROUTER_API_KEY` in the environment to fully exercise OpenRouter-related tests.
+- Allow outbound traffic to `openrouter.ai` so the backend can communicate with the OpenRouter service.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -35,7 +35,7 @@ vllm:
 # OpenRouter backend configuration
 openrouter:
   api_key: ""  # Set your OpenRouter API key here or use OPENROUTER_API_KEY env var
-  model: "qwen/qwen-2.5-coder-32b-instruct"
+  model: "deepseek/deepseek-r1-0528-qwen3-8b"
   timeout: 300
   base_url: "https://openrouter.ai/api/v1"
 

--- a/src/qwen_tui/cli/setup.py
+++ b/src/qwen_tui/cli/setup.py
@@ -311,12 +311,13 @@ def setup_openrouter_interactive(config) -> None:
     
     # Model selection
     suggested_models = [
+        "deepseek/deepseek-r1-0528-qwen3-8b",
         "qwen/qwen-2.5-coder-32b-instruct",
         "qwen/qwen-2.5-coder-14b-instruct",
         "qwen/qwen-2.5-coder-7b-instruct",
         "qwen/qwen-2.5-32b-instruct",
         "qwen/qwen-2.5-14b-instruct",
-        "qwen/qwen-2.5-7b-instruct"
+        "qwen/qwen-2.5-7b-instruct",
     ]
     
     console.print("\n[bold]Suggested Qwen models on OpenRouter:[/bold]")

--- a/src/qwen_tui/config.py
+++ b/src/qwen_tui/config.py
@@ -67,7 +67,10 @@ class VLLMConfig(BaseModel):
 class OpenRouterConfig(BaseModel):
     """OpenRouter backend configuration."""
     api_key: str = Field(..., description="OpenRouter API key")
-    model: str = Field(default="qwen/qwen-2.5-coder-32b-instruct", description="Model to use")
+    model: str = Field(
+        default="deepseek/deepseek-r1-0528-qwen3-8b",
+        description="Model to use",
+    )
     timeout: int = Field(default=300, description="Request timeout in seconds")
     base_url: str = Field(default="https://openrouter.ai/api/v1", description="API base URL")
 


### PR DESCRIPTION
## Summary
- update default OpenRouter model to `deepseek/deepseek-r1-0528-qwen3-8b`
- update example configuration and README to use the new model
- extend CLI model suggestions with the DeepSeek model
- add a testing report documenting pytest results and OpenRouter connectivity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685428b55a088324b723cb55c89f3e81