### PR TITLE
Fix TUI log output

### DIFF
--- a/src/qwen_tui/logging.py
+++ b/src/qwen_tui/logging.py
@@ -63,10 +63,11 @@ def setup_logging(config: LoggingConfig, tui_mode: bool = False) -> None:
             config.file = os.path.join(log_dir, "qwen-tui.log")
         
         # Don't configure console logging in TUI mode
+        # Install a NullHandler so Textual doesn't add its own handler
         logging.basicConfig(
             format="%(message)s",
             level=getattr(logging, config.level.value),
-            handlers=[]  # No handlers for stdout in TUI mode
+            handlers=[logging.NullHandler()]  # Prevent Textual from reconfiguring
         )
     else:
         # Normal CLI mode - use stdout
@@ -90,10 +91,10 @@ def setup_logging(config: LoggingConfig, tui_mode: bool = False) -> None:
         )
         file_handler.setLevel(getattr(logging, config.level.value))
         
-        # Create a separate logger for file output
-        file_logger = logging.getLogger("qwen_tui.file")
-        file_logger.addHandler(file_handler)
-        file_logger.setLevel(getattr(logging, config.level.value))
+        # Attach file handler to the root logger so all logs are captured
+        root_logger = logging.getLogger()
+        root_logger.addHandler(file_handler)
+        root_logger.setLevel(getattr(logging, config.level.value))
     
     # Configure processors based on format
     processors = [


### PR DESCRIPTION
## Summary
- fix TUI logging so Textual won't attach its own handler
- log to file from root logger to keep messages out of the terminal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854893297d48324a68a679bd42d760b