### PR TITLE
Fix think tag filtering in protocol mode

### DIFF
--- a/tests/test_protocol_thinking.py
+++ b/tests/test_protocol_thinking.py
@@ -1,0 +1,29 @@
+import pytest
+from qwen_tui.tui.thinking import ThinkingManager
+from qwen_tui.backends.manager import BackendManager
+from qwen_tui.config import Config
+from qwen_tui.backends.base import LLMResponse, LLMRequest
+
+class DummyProtocolClient:
+    async def generate(self, request: LLMRequest):
+        # Simulate streaming with think tags
+        yield LLMResponse(is_partial=True, delta="<think>Hidden</think>")
+        yield LLMResponse(content="Visible reply", is_partial=False)
+
+@pytest.mark.asyncio
+async def test_protocol_think_tags_hidden():
+    config = Config()
+    backend_manager = BackendManager(config)
+    client = DummyProtocolClient()
+    manager = ThinkingManager(backend_manager, config, protocol_client=client)
+
+    chunks = []
+    async for chunk in manager.think_and_respond("Hello"):
+        chunks.append(chunk)
+
+    result = "".join(chunks)
+    state = manager.get_thinking_state()
+
+    assert "<think>" not in result
+    assert "Hidden" in state.full_thoughts
+


### PR DESCRIPTION
## Summary
- filter `<think>` tags when using `ProtocolClient`
- add regression test for protocol client path

## Testing
- `pytest -q tests/test_protocol_thinking.py tests/test_thinking_filter.py tests/test_thinking_integration.py`
- `pytest -q tests/test_backends.py tests/test_config.py tests/test_history.py tests/test_tui.py`

------
https://chatgpt.com/codex/tasks/task_e_6854a20803b4832483ec8df089175796